### PR TITLE
Exclude value from indexes so values can be larger

### DIFF
--- a/gcd.py
+++ b/gcd.py
@@ -40,7 +40,7 @@ class CloudDatastore(StorageBase):
         self.ds.delete(key)
 
     def set(self, key: str, value: Any) -> None:
-        ent = datastore.Entity(key=self._gkey(key))
+        ent = datastore.Entity(key=self._gkey(key), exclude_from_indexes=['value'])
         ent['value'] = encode(value)
         self.ds.put(ent)
 


### PR DESCRIPTION
GCD limits indexed properties to 1500 bytes, unindexed to 1,048,487 bytes. 1500 is too small for repo_index.
